### PR TITLE
feat: add config fallback

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+// Determine path to the user-provided config file
+const configPath = path.join(__dirname, 'config.json');
+const exampleConfigPath = path.join(__dirname, 'config.example.json');
+
+let config;
+if (fs.existsSync(configPath)) {
+  // Load user configuration
+  config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+} else {
+  // Fall back to example configuration
+  console.warn('config.json not found, falling back to config.example.json');
+  config = JSON.parse(fs.readFileSync(exampleConfigPath, 'utf8'));
+}
+
+module.exports = config;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -4,7 +4,8 @@ const path = require('path');
 const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
 const moment = require('moment');
-const config = require('../config.json');
+// Use shared configuration loader
+const config = require('../config');
 const crypto = require('crypto');
 
 // 会话存储（生产环境建议使用 Redis 或数据库）

--- a/routes/api.js
+++ b/routes/api.js
@@ -2,7 +2,8 @@ const express = require('express');
 const router = express.Router();
 const path = require('path');
 const fs = require('fs');
-const config = require('../config.json');
+// Use shared configuration loader
+const config = require('../config');
 
 // 工具函数
 const readJsonFile = (filePath) => {

--- a/routes/student.js
+++ b/routes/student.js
@@ -4,7 +4,8 @@ const path = require('path');
 const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
 const moment = require('moment');
-const config = require('../config.json');
+// Use shared configuration loader
+const config = require('../config');
 
 // 工具函数
 const readJsonFile = (filePath) => {

--- a/server.js
+++ b/server.js
@@ -3,7 +3,8 @@ const cors = require('cors');
 const bodyParser = require('body-parser');
 const path = require('path');
 const fs = require('fs');
-const config = require('./config.json');
+// Load configuration, falling back to example config if necessary
+const config = require('./config');
 
 const app = express();
 const PORT = config.server.port || 3000;


### PR DESCRIPTION
## Summary
- handle missing config.json by falling back to config.example.json
- switch server and route modules to use shared configuration loader

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "require('./config');"`
- `node -e "require('./server'); setTimeout(()=>process.exit(0), 1000);"`


------
https://chatgpt.com/codex/tasks/task_b_6898a8f8c5548323bef25d761f26fe6a