### PR TITLE
Add React admin and student pages with responsive details

### DIFF
--- a/frontend/public/css/admin.css
+++ b/frontend/public/css/admin.css
@@ -306,10 +306,11 @@
   margin-bottom: 24px;
 }
 
-.info-item {
+.info-card {
   padding: 16px;
   background: var(--background-color);
   border-radius: 8px;
+  border-left: 4px solid var(--primary-color);
 }
 
 .info-label {

--- a/frontend/public/css/common.css
+++ b/frontend/public/css/common.css
@@ -169,10 +169,13 @@ img, video, iframe {
 .action-card {
   text-align: center;
   transition: transform var(--transition-normal);
+}
+
+.action-card.clickable {
   cursor: pointer;
 }
 
-.action-card:hover {
+.action-card.clickable:hover {
   transform: translateY(-4px);
   box-shadow: var(--shadow-3);
 }
@@ -190,6 +193,17 @@ img, video, iframe {
 
 .action-card p {
   margin-bottom: 20px;
+}
+
+/* Input group */
+.input-group {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+
+.input-group input {
+  flex: 1;
 }
 
 /* Features Section */
@@ -614,5 +628,8 @@ img, video, iframe {
   
   .toast.show {
     transform: translateY(0);
+  }
+  .input-group {
+    flex-direction: column;
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,22 +1,18 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
+import Admin from './pages/Admin';
+import Student from './pages/Student';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/admin" element={<AdminRedirect />} />
+        <Route path="/admin" element={<Admin />} />
+        <Route path="/student/assignment/:assignmentId" element={<Student />} />
       </Routes>
     </BrowserRouter>
   );
-}
-
-// Component to redirect to the actual admin page
-function AdminRedirect() {
-  // Redirect to the actual admin page served by Express
-  window.location.href = '/admin';
-  return <div>正在跳转到管理后台...</div>;
 }
 
 export default App;

--- a/frontend/src/components/ActionCard.jsx
+++ b/frontend/src/components/ActionCard.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function ActionCard({ icon, title, description, children, onClick }) {
+  const className = `card action-card${onClick ? ' clickable' : ''}`;
+  return (
+    <div className={className} onClick={onClick}>
+      <div className="card-content">
+        {icon && <i className="material-icons">{icon}</i>}
+        {title && <h3>{title}</h3>}
+        {description && <p>{description}</p>}
+        {children}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/AssignmentInput.jsx
+++ b/frontend/src/components/AssignmentInput.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export default function AssignmentInput({ value, onChange, onSubmit }) {
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      onSubmit();
+    }
+  };
+
+  return (
+    <div className="input-group">
+      <input
+        type="text"
+        value={value}
+        onChange={onChange}
+        onKeyDown={handleKeyDown}
+        placeholder="请输入作业ID或完整链接"
+        className="form-control"
+        aria-label="作业ID或链接"
+      />
+      <button className="btn btn-primary" onClick={onSubmit}>
+        开始答题
+      </button>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import ActionCard from '../components/ActionCard';
+import '/css/admin.css';
+
+export default function Admin() {
+  const [assignments, setAssignments] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetch('/admin/assignments')
+      .then(res => res.json())
+      .then(data => setAssignments(data.assignments || []))
+      .catch(() => setError('加载作业失败'));
+  }, []);
+
+  const viewDetails = (id) => {
+    fetch(`/admin/assignments/${id}`)
+      .then(res => res.json())
+      .then(setSelected)
+      .catch(() => setError('加载详情失败'));
+  };
+
+  return (
+    <div className="admin-layout">
+      <main className="admin-main">
+        <h2>作业管理</h2>
+        {error && <p className="text-error">{error}</p>}
+
+        <div className="stats-dashboard">
+          {assignments.map(a => (
+            <ActionCard
+              key={a.id}
+              title={a.title}
+              description={a.description}
+              onClick={() => viewDetails(a.id)}
+            >
+              <div className="info-label">提交数: {a.submissionCount || 0}</div>
+            </ActionCard>
+          ))}
+        </div>
+
+        {selected && (
+          <section className="assignment-info" style={{ marginTop: '24px' }}>
+            <div className="info-card">
+              <div className="info-label">标题</div>
+              <div className="info-value">{selected.title}</div>
+            </div>
+            <div className="info-card">
+              <div className="info-label">创建时间</div>
+              <div className="info-value">{new Date(selected.createdAt).toLocaleString()}</div>
+            </div>
+            <div className="info-card">
+              <div className="info-label">截止时间</div>
+              <div className="info-value">{selected.dueDate ? new Date(selected.dueDate).toLocaleString() : '无限制'}</div>
+            </div>
+            <div className="info-card">
+              <div className="info-label">状态</div>
+              <div className="info-value">{selected.status}</div>
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { showMessage } from '../utils/message';
+import ActionCard from '../components/ActionCard';
+import AssignmentInput from '../components/AssignmentInput';
 
 export default function Home() {
   const [assignmentId, setAssignmentId] = useState('');
@@ -25,12 +27,6 @@ export default function Home() {
     }
   };
 
-  const handleKeyPress = (e) => {
-    if (e.key === 'Enter') {
-      handleStart();
-    }
-  };
-
   return (
     <div className="container">
       <header className="header">
@@ -46,35 +42,26 @@ export default function Home() {
       <main className="main-content">
         <div className="action-section">
           <div className="action-cards">
-            <div className="card action-card" onClick={() => { window.location.href = '/admin'; }}>
-              <div className="card-content">
-                <i className="material-icons">admin_panel_settings</i>
-                <h3>管理后台</h3>
-                <p>创建和管理作业，查看学生提交情况和统计数据</p>
-                <button className="btn btn-primary">进入管理后台</button>
-              </div>
-            </div>
+            <ActionCard
+              icon="admin_panel_settings"
+              title="管理后台"
+              description="创建和管理作业，查看学生提交情况和统计数据"
+              onClick={() => { navigate('/admin'); }}
+            >
+              <button className="btn btn-primary">进入管理后台</button>
+            </ActionCard>
 
-            <div className="card action-card">
-              <div className="card-content">
-                <i className="material-icons">assignment</i>
-                <h3>学生答题</h3>
-                <p>输入作业链接或ID开始答题</p>
-                <div className="input-group">
-                  <input
-                    type="text"
-                    value={assignmentId}
-                    onChange={(e) => setAssignmentId(e.target.value)}
-                    onKeyPress={handleKeyPress}
-                    placeholder="请输入作业ID或完整链接"
-                    className="form-control"
-                  />
-                  <button className="btn btn-primary" onClick={handleStart}>
-                    开始答题
-                  </button>
-                </div>
-              </div>
-            </div>
+            <ActionCard
+              icon="assignment"
+              title="学生答题"
+              description="输入作业链接或ID开始答题"
+            >
+              <AssignmentInput
+                value={assignmentId}
+                onChange={(e) => setAssignmentId(e.target.value)}
+                onSubmit={handleStart}
+              />
+            </ActionCard>
           </div>
         </div>
       </main>

--- a/frontend/src/pages/Student.jsx
+++ b/frontend/src/pages/Student.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import '/css/student.css';
+
+export default function Student() {
+  const { assignmentId } = useParams();
+  const [assignment, setAssignment] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetch(`/student/api/${assignmentId}`)
+      .then(res => res.json())
+      .then(setAssignment)
+      .catch(() => setError('加载作业失败'));
+  }, [assignmentId]);
+
+  if (error) {
+    return <div className="error-state"><p>{error}</p></div>;
+  }
+
+  if (!assignment) {
+    return <div className="loading-state"><p>加载中...</p></div>;
+  }
+
+  return (
+    <div className="main-content">
+      <div className="assignment-header">
+        <h2>{assignment.title}</h2>
+        {assignment.description && (
+          <p className="text-secondary">{assignment.description}</p>
+        )}
+      </div>
+
+      <ol>
+        {assignment.questions?.map((q, idx) => (
+          <li key={q.id || idx} className="question-item">
+            {q.question}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -331,10 +331,11 @@
   margin-bottom: 24px;
 }
 
-.info-item {
+.info-card {
   padding: 16px;
   background: var(--background-color);
   border-radius: 8px;
+  border-left: 4px solid var(--primary-color);
 }
 
 .info-label {
@@ -834,24 +835,6 @@
 }
 
 /* Assignment Overview Styles */
-.assignment-info {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-bottom: 20px;
-}
-
-.assignment-info .info-card {
-  flex: 1;
-  min-width: 150px;
-}
-
-.info-card {
-  background: #f8f9fa;
-  padding: 16px;
-  border-radius: 8px;
-  border-left: 4px solid #018eee;
-}
 
 .info-label {
   font-size: 12px;
@@ -1001,6 +984,14 @@
 
 .table {
   min-width: 600px;
+}
+
+/* Responsive stats grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 24px;
+  margin-bottom: 24px;
 }
 
 /* Mobile-first Card Layout for Tables */
@@ -1322,8 +1313,8 @@
   
   /* 移动端网格系统 */
   .stats-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 16px;
   }
   
   /* 移动端卡片容器优化 */
@@ -1436,7 +1427,7 @@
   }
   
   .stats-grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     gap: 16px;
     margin-bottom: 24px;
   }
@@ -1574,7 +1565,7 @@
 
   .stats-grid {
     grid-template-columns: 1fr;
-    gap: 6px;
+    gap: 8px;
   }
 
   .stat-card {
@@ -1590,10 +1581,6 @@
   .page-header {
     gap: 8px;
     margin-bottom: 16px;
-  }
-  
-  .stats-grid {
-    grid-template-columns: 1fr;
   }
   
   /* 移动端卡片布局超紧凑优化 */
@@ -1863,13 +1850,13 @@
   
   /* 超小屏幕概览优化 */
   .assignment-info {
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
     gap: 6px;
     margin-bottom: 10px;
   }
-  
+
   .assignment-info .info-card {
-    flex: none;
     min-width: auto;
   }
   
@@ -1976,16 +1963,16 @@
   
   /* 概览标签页移动端优化 */
   .assignment-info {
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
     gap: 8px;
     margin-bottom: 12px;
   }
-  
+
   .assignment-info .info-card {
-    flex: none;
     min-width: auto;
   }
-  
+
   .info-card {
     padding: 8px;
     border-left-width: 3px;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -67,6 +67,24 @@ class AdminPanel {
     } catch (error) {
       console.error('加载作业列表失败:', error);
       Utils.showMessage('加载作业列表失败', 'error');
+      const tbody = document.getElementById('assignments-list');
+      const mobileContainer = document.getElementById('assignments-mobile-list');
+      if (tbody) {
+        tbody.innerHTML = `
+          <tr>
+            <td colspan="6" class="text-center text-error">加载作业列表失败</td>
+          </tr>
+        `;
+      }
+      if (mobileContainer) {
+        mobileContainer.innerHTML = `
+          <div class="empty-state">
+            <i class="material-icons">error</i>
+            <h3>加载作业列表失败</h3>
+            <p>请稍后重试</p>
+          </div>
+        `;
+      }
     }
   }
   
@@ -76,6 +94,7 @@ class AdminPanel {
       this.updateStatsCards(stats);
     } catch (error) {
       console.error('加载系统统计失败:', error);
+      Utils.showMessage('加载系统统计失败', 'error');
     }
   }
   


### PR DESCRIPTION
## Summary
- add React Admin and Student pages with data fetching
- standardize assignment detail styling using grid-based info-card layout
- update routes and navigation to use new React pages

## Testing
- `npm test`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_b_689ded777b548323ae080ebcfccba141