### PR TITLE
feat: add responsive admin dashboard and detail view

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import AssignmentDetail from './pages/AssignmentDetail';
+import AdminDashboard from './pages/AdminDashboard';
 
 function App() {
   return (
@@ -8,17 +9,9 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/student/assignment/:id" element={<AssignmentDetail />} />
-        <Route path="/admin" element={<AdminRedirect />} />
+        <Route path="/admin/*" element={<AdminDashboard />} />
       </Routes>
     </BrowserRouter>
   );
 }
-
-// Component to redirect to the actual admin page
-function AdminRedirect() {
-  // Redirect to the actual admin page served by Express
-  window.location.href = '/admin';
-  return <div>正在跳转到管理后台...</div>;
-}
-
 export default App;

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import '../styles/admin-dashboard.css';
+
+// simple api helper with session header
+function useApi() {
+  const base = '';
+  async function get(url) {
+    const sessionId = localStorage.getItem('adminSession') || '';
+    const res = await fetch(`${base}${url}`, {
+      headers: { 'x-session-id': sessionId }
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || '请求失败');
+    }
+    return res.json();
+  }
+  return { get };
+}
+
+export default function AdminDashboard() {
+  const api = useApi();
+  const [assignments, setAssignments] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const data = await api.get('/admin/assignments');
+        if (!mounted) return;
+        setAssignments(data.assignments || []);
+      } catch (e) {
+        setError(e.message);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function openAssignment(a) {
+    setSelected(null);
+    try {
+      const detail = await api.get(`/admin/assignments/${a.id}`);
+      setSelected(detail);
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  return (
+    <div className="admin-dashboard">
+      <header className="admin-header">
+        <h1>作业管理</h1>
+      </header>
+      <div className="admin-main">
+        <div className="assignment-list">
+          {loading && <p>加载中...</p>}
+          {error && <p className="error">{error}</p>}
+          {!loading && !error && assignments.map(a => (
+            <div key={a.id} className="assignment-item" onClick={() => openAssignment(a)}>
+              <h3>{a.title}</h3>
+              <p className="assignment-meta">
+                {a.dueDate ? new Date(a.dueDate).toLocaleString() : '无截止时间'}
+              </p>
+            </div>
+          ))}
+        </div>
+        {selected && (
+          <div className="assignment-detail">
+            <div className="detail-header">
+              <button className="btn-close" onClick={() => setSelected(null)}>&times;</button>
+              <h2>{selected.title}</h2>
+            </div>
+            {selected.description && (
+              <p className="detail-description">{selected.description}</p>
+            )}
+            <ul className="detail-list">
+              <li><strong>截止时间：</strong>{selected.dueDate ? new Date(selected.dueDate).toLocaleString() : '无'}</li>
+              <li><strong>题目数：</strong>{selected.questions ? selected.questions.length : 0}</li>
+              <li><strong>状态：</strong>{selected.status || '未知'}</li>
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AssignmentDetail.jsx
+++ b/frontend/src/pages/AssignmentDetail.jsx
@@ -57,7 +57,7 @@ export default function AssignmentDetail() {
       }
     })();
     return () => { mounted = false; };
-  }, [id]);
+  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const questionCount = assignment?.questions?.length || 0;
   const dueLabel = useMemo(() => {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -46,7 +46,7 @@ export default function Home() {
               icon="admin_panel_settings"
               title="管理后台"
               description="创建和管理作业，查看学生提交情况和统计数据"
-              onClick={() => { window.location.href = '/admin'; }}
+              onClick={() => navigate('/admin')}
             >
               <button className="btn btn-primary">进入管理后台</button>
             </ActionCard>

--- a/frontend/src/styles/admin-dashboard.css
+++ b/frontend/src/styles/admin-dashboard.css
@@ -1,0 +1,117 @@
+.admin-dashboard {
+  min-height: 100vh;
+  background: #f5f6fa;
+  font-family: 'Roboto', -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #333;
+}
+
+.admin-header {
+  background: #fff;
+  padding: 16px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.admin-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.admin-main {
+  display: flex;
+  flex-direction: column;
+}
+
+.assignment-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.assignment-item {
+  padding: 12px 16px;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+.assignment-item h3 {
+  margin: 0 0 4px;
+  font-size: 1rem;
+}
+
+.assignment-item .assignment-meta {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #666;
+}
+
+.assignment-item:hover,
+.assignment-item.active {
+  background: #e8f0fe;
+}
+
+.assignment-detail {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #fff;
+  padding: 20px;
+  overflow-y: auto;
+  z-index: 20;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.btn-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.detail-description {
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.detail-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.detail-list li {
+  margin-bottom: 8px;
+}
+
+.error {
+  color: #d32f2f;
+  padding: 12px;
+}
+
+/* Desktop layout */
+@media (min-width: 768px) {
+  .admin-main {
+    flex-direction: row;
+  }
+  .assignment-list {
+    width: 35%;
+    border-right: 1px solid #eee;
+    max-height: calc(100vh - 64px);
+  }
+  .assignment-detail {
+    position: static;
+    width: 65%;
+    box-shadow: none;
+  }
+}

--- a/frontend/src/styles/assignment-detail.css
+++ b/frontend/src/styles/assignment-detail.css
@@ -383,3 +383,19 @@
     flex: none;
   }
 }
+
+/* Desktop enhancements */
+@media (min-width: 1024px) {
+  .assignment-header {
+    grid-template-columns: 2fr 1fr;
+    align-items: flex-start;
+  }
+  .student-display {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
+  }
+  .assignment-info {
+    padding-right: 40px;
+  }
+}


### PR DESCRIPTION
## Summary
- add React-based AdminDashboard with assignment list and responsive detail panel
- enable navigation to new dashboard and route within app
- enhance assignment detail styles for desktop layouts

## Testing
- `npm --prefix frontend run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a09a66bfd88323b3c0376046246d62