### PR TITLE
feat(frontend): rebuild admin dashboard

### DIFF
--- a/frontend/src/components/admin/AssignmentDetails.jsx
+++ b/frontend/src/components/admin/AssignmentDetails.jsx
@@ -1,0 +1,200 @@
+import React, { useMemo, useState } from 'react';
+
+export default function AssignmentDetails({ assignment, onClose, onDelete, copyLink }) {
+  const [tab, setTab] = useState('overview');
+  const [search, setSearch] = useState('');
+  const [classFilter, setClassFilter] = useState('');
+
+  const submissions = useMemo(
+    () => assignment.stats?.submissions || [],
+    [assignment.stats]
+  );
+  const classes = useMemo(
+    () => Array.from(new Set(submissions.map((s) => s.studentInfo.className))),
+    [submissions]
+  );
+
+  const filteredSubmissions = submissions
+    .filter((s) =>
+      !search ||
+      s.studentInfo.name.toLowerCase().includes(search.toLowerCase()) ||
+      s.studentInfo.className.toLowerCase().includes(search.toLowerCase())
+    )
+    .filter((s) => !classFilter || s.studentInfo.className === classFilter)
+    .sort((a, b) => new Date(b.submittedAt) - new Date(a.submittedAt));
+
+  const recentSubmissions = filteredSubmissions.slice(0, 10);
+
+  const statsByClass = assignment.stats?.detailedStatistics?.submissionsByClass || {};
+
+  return (
+    <div className="card assignment-details">
+      <div className="card-header">
+        <h3>{assignment.title}</h3>
+        <div className="action-buttons">
+          <button className="btn btn-secondary" onClick={() => copyLink(assignment.id)}>
+            复制链接
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={() => onDelete(assignment.id)}
+          >
+            删除
+          </button>
+          <button className="btn btn-secondary" onClick={onClose}>
+            关闭
+          </button>
+        </div>
+      </div>
+
+      <div className="detail-tabs">
+        <button
+          className={tab === 'overview' ? 'active' : ''}
+          onClick={() => setTab('overview')}
+        >
+          概览
+        </button>
+        <button
+          className={tab === 'submissions' ? 'active' : ''}
+          onClick={() => setTab('submissions')}
+        >
+          学生答题
+        </button>
+        <button
+          className={tab === 'analytics' ? 'active' : ''}
+          onClick={() => setTab('analytics')}
+        >
+          题目分析
+        </button>
+      </div>
+
+      {tab === 'overview' && (
+        <ul className="detail-list">
+          {assignment.description && <li>{assignment.description}</li>}
+          <li>
+            <strong>截止时间：</strong>
+            {assignment.dueDate
+              ? new Date(assignment.dueDate).toLocaleString()
+              : '无'}
+          </li>
+          <li>
+            <strong>题目数：</strong>
+            {assignment.questions ? assignment.questions.length : 0}
+          </li>
+          <li>
+            <strong>状态：</strong>
+            {assignment.status || '未知'}
+          </li>
+          <li>
+            <strong>总提交数：</strong>
+            {assignment.stats?.statistics?.totalSubmissions || 0}
+          </li>
+          {recentSubmissions.length > 0 && (
+            <li>
+              <strong>最近提交：</strong>
+              <ul className="submission-list">
+                {recentSubmissions.slice(0, 5).map((sub) => (
+                  <li key={sub.id} className="submission-item">
+                    <span>{sub.studentInfo.name}</span>
+                    <span>{sub.studentInfo.className}</span>
+                    <span>{sub.percentage}%</span>
+                    <span>
+                      {new Date(sub.submittedAt).toLocaleString()}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          )}
+        </ul>
+      )}
+
+      {tab === 'submissions' && (
+        <div className="detail-content">
+          <div className="submission-filters">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="搜索学生姓名或班级"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            <select
+              className="form-control"
+              value={classFilter}
+              onChange={(e) => setClassFilter(e.target.value)}
+            >
+              <option value="">所有班级</option>
+              {classes.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="table-container" style={{ marginTop: '1rem' }}>
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>学生姓名</th>
+                  <th>班级</th>
+                  <th>得分</th>
+                  <th>提交时间</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredSubmissions.map((sub) => (
+                  <tr key={sub.id}>
+                    <td>{sub.studentInfo.name}</td>
+                    <td>{sub.studentInfo.className}</td>
+                    <td>{sub.percentage}%</td>
+                    <td>{new Date(sub.submittedAt).toLocaleString()}</td>
+                  </tr>
+                ))}
+                {filteredSubmissions.length === 0 && (
+                  <tr>
+                    <td colSpan="4" className="text-center">
+                      暂无提交
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {tab === 'analytics' && (
+        <div className="detail-content">
+          <h4>班级提交统计</h4>
+          <div className="table-container" style={{ marginTop: '1rem' }}>
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>班级</th>
+                  <th>提交数</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(statsByClass).map(([cls, count]) => (
+                  <tr key={cls}>
+                    <td>{cls}</td>
+                    <td>{count}</td>
+                  </tr>
+                ))}
+                {Object.keys(statsByClass).length === 0 && (
+                  <tr>
+                    <td colSpan="2" className="text-center">
+                      暂无数据
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/AssignmentForm.jsx
+++ b/frontend/src/components/admin/AssignmentForm.jsx
@@ -1,0 +1,277 @@
+import React, { useState } from 'react';
+
+function uid() {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+export default function AssignmentForm({ api, onCreated, onCancel }) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [questions, setQuestions] = useState([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  function addQuestion() {
+    setQuestions([
+      ...questions,
+      {
+        id: uid(),
+        type: 'single-choice',
+        text: '',
+        options: ['', ''],
+        correct: [0]
+      }
+    ]);
+  }
+
+  function updateQuestion(i, updates) {
+    setQuestions((qs) => qs.map((q, idx) => (idx === i ? { ...q, ...updates } : q)));
+  }
+
+  function removeQuestion(i) {
+    setQuestions((qs) => qs.filter((_, idx) => idx !== i));
+  }
+
+  function addOption(i) {
+    updateQuestion(i, { options: [...questions[i].options, ''] });
+  }
+
+  function updateOption(i, j, value) {
+    const opts = [...questions[i].options];
+    opts[j] = value;
+    updateQuestion(i, { options: opts });
+  }
+
+  function removeOption(i, j) {
+    const opts = questions[i].options.filter((_, idx) => idx !== j);
+    const corr = questions[i].correct.filter((c) => c !== j).map((c) => (c > j ? c - 1 : c));
+    updateQuestion(i, { options: opts, correct: corr });
+  }
+
+  function toggleCorrect(i, j) {
+    const q = questions[i];
+    if (q.type === 'single-choice') {
+      updateQuestion(i, { correct: [j] });
+    } else {
+      const exists = q.correct.includes(j);
+      updateQuestion(i, {
+        correct: exists ? q.correct.filter((c) => c !== j) : [...q.correct, j]
+      });
+    }
+  }
+
+  async function submit(e) {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('请输入作业标题');
+      return;
+    }
+    if (questions.length === 0) {
+      setError('请至少添加一个题目');
+      return;
+    }
+    for (const q of questions) {
+      if (!q.text.trim()) {
+        setError('题目内容不能为空');
+        return;
+      }
+      if (q.type !== 'short-answer') {
+        const opts = q.options.map((o) => o.trim()).filter(Boolean);
+        if (opts.length < 2) {
+          setError('每个选择题至少需要两个选项');
+          return;
+        }
+        if (q.correct.length === 0) {
+          setError('请选择正确答案');
+          return;
+        }
+      } else if (!q.answer || !q.answer.trim()) {
+        setError('请填写简答题答案');
+        return;
+      }
+    }
+
+    const payloadQuestions = questions.map((q) => {
+      const base = {
+        id: q.id,
+        type: q.type,
+        question: q.text,
+        points: 1,
+        required: true
+      };
+      if (q.type === 'short-answer') {
+        base.correctAnswer = q.answer;
+      } else {
+        base.options = q.options.map((o) => o.trim());
+        if (q.type === 'single-choice') {
+          base.correctAnswer = q.correct[0];
+        } else {
+          base.correctAnswers = q.correct;
+        }
+      }
+      return base;
+    });
+
+    setSaving(true);
+    setError('');
+    try {
+      await api.post('/admin/assignments', {
+        title: title.trim(),
+        description: description.trim(),
+        dueDate: dueDate || null,
+        questions: payloadQuestions
+      });
+      onCreated();
+      setTitle('');
+      setDescription('');
+      setDueDate('');
+      setQuestions([]);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="card" style={{ marginBottom: '24px' }}>
+      <div className="card-header">
+        <h3>创建作业</h3>
+        <button className="btn btn-secondary" onClick={onCancel} disabled={saving}>
+          取消
+        </button>
+      </div>
+      <div className="card-content">
+        {error && <p className="text-error" style={{ marginBottom: '1rem' }}>{error}</p>}
+        <form onSubmit={submit}>
+          <div className="form-group">
+            <label className="form-label">标题</label>
+            <input
+              type="text"
+              className="form-control"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <label className="form-label">描述</label>
+            <textarea
+              className="form-control"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <label className="form-label">截止时间</label>
+            <input
+              type="datetime-local"
+              className="form-control"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+            />
+          </div>
+
+          {questions.map((q, i) => (
+            <div key={q.id} className="card" style={{ marginBottom: '16px' }}>
+              <div className="card-header">
+                <h4>题目 {i + 1}</h4>
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={() => removeQuestion(i)}
+                >
+                  删除
+                </button>
+              </div>
+              <div className="card-content">
+                <div className="form-group">
+                  <label className="form-label">题目内容</label>
+                  <textarea
+                    className="form-control"
+                    value={q.text}
+                    onChange={(e) => updateQuestion(i, { text: e.target.value })}
+                  />
+                </div>
+                <div className="form-group">
+                  <label className="form-label">题目类型</label>
+                  <select
+                    className="form-control"
+                    value={q.type}
+                    onChange={(e) => updateQuestion(i, { type: e.target.value, correct: [], options: e.target.value === 'short-answer' ? undefined : q.options })}
+                  >
+                    <option value="single-choice">单选题</option>
+                    <option value="multiple-choice">多选题</option>
+                    <option value="short-answer">简答题</option>
+                  </select>
+                </div>
+                {q.type !== 'short-answer' ? (
+                  <div>
+                    {q.options.map((opt, j) => (
+                      <div key={j} className="form-group" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        {q.type === 'single-choice' ? (
+                          <input
+                            type="radio"
+                            name={`correct-${q.id}`}
+                            checked={q.correct[0] === j}
+                            onChange={() => toggleCorrect(i, j)}
+                          />
+                        ) : (
+                          <input
+                            type="checkbox"
+                            checked={q.correct.includes(j)}
+                            onChange={() => toggleCorrect(i, j)}
+                          />
+                        )}
+                        <input
+                          type="text"
+                          className="form-control"
+                          value={opt}
+                          onChange={(e) => updateOption(i, j, e.target.value)}
+                        />
+                        {q.options.length > 2 && (
+                          <button
+                            type="button"
+                            className="btn btn-secondary"
+                            onClick={() => removeOption(i, j)}
+                          >
+                            删除
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      className="btn btn-primary"
+                      onClick={() => addOption(i)}
+                    >
+                      添加选项
+                    </button>
+                  </div>
+                ) : (
+                  <div className="form-group">
+                    <label className="form-label">参考答案</label>
+                    <textarea
+                      className="form-control"
+                      value={q.answer || ''}
+                      onChange={(e) => updateQuestion(i, { answer: e.target.value })}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+          <div style={{ marginBottom: '16px' }}>
+            <button type="button" className="btn btn-primary" onClick={addQuestion}>
+              添加题目
+            </button>
+          </div>
+          <button type="submit" className="btn btn-primary" disabled={saving}>
+            {saving ? '保存中...' : '保存作业'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/Assignments.jsx
+++ b/frontend/src/components/admin/Assignments.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import AssignmentForm from './AssignmentForm';
 import AssignmentDetails from './AssignmentDetails';
+import Modal from './Modal';
 
 export default function Assignments({ api }) {
   const [assignments, setAssignments] = useState([]);
@@ -213,15 +214,17 @@ export default function Assignments({ api }) {
       </div>
 
       {selected && (
-        <AssignmentDetails
-          assignment={selected}
-          onClose={() => setSelected(null)}
-          onDelete={(id) => {
-            deleteAssignment(id);
-            setSelected(null);
-          }}
-          copyLink={copyLink}
-        />
+        <Modal onClose={() => setSelected(null)}>
+          <AssignmentDetails
+            assignment={selected}
+            onClose={() => setSelected(null)}
+            onDelete={(id) => {
+              deleteAssignment(id);
+              setSelected(null);
+            }}
+            copyLink={copyLink}
+          />
+        </Modal>
       )}
     </div>
   );

--- a/frontend/src/components/admin/Assignments.jsx
+++ b/frontend/src/components/admin/Assignments.jsx
@@ -1,0 +1,229 @@
+import React, { useEffect, useState } from 'react';
+import AssignmentForm from './AssignmentForm';
+import AssignmentDetails from './AssignmentDetails';
+
+export default function Assignments({ api }) {
+  const [assignments, setAssignments] = useState([]);
+  const [stats, setStats] = useState(null);
+  const [filter, setFilter] = useState('');
+  const [selected, setSelected] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [showForm, setShowForm] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    setError('');
+    try {
+      const [a, s] = await Promise.all([
+        api.get('/admin/assignments'),
+        api.get('/api/stats')
+      ]);
+      setAssignments(a.assignments || []);
+      setStats(s);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const filtered = assignments.filter((a) =>
+    a.title.toLowerCase().includes(filter.toLowerCase())
+  );
+
+  async function openAssignment(id) {
+    try {
+      const [detail, stat] = await Promise.all([
+        api.get(`/admin/assignments/${id}`),
+        api.get(`/admin/assignments/${id}/statistics`).catch(() => null)
+      ]);
+      setSelected({ ...detail, stats: stat });
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  async function deleteAssignment(id) {
+    if (!window.confirm('确定要删除该作业吗？')) return;
+    try {
+      await api.del(`/admin/assignments/${id}`);
+      load();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  function copyLink(id) {
+    const url = `${window.location.origin}/student/assignment/${id}`;
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(url);
+    } else {
+      const input = document.createElement('input');
+      input.value = url;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand('copy');
+      document.body.removeChild(input);
+    }
+    alert('链接已复制');
+  }
+
+  return (
+    <div id="assignments-tab" className="tab-content active">
+      <div className="page-header">
+        <h2>作业管理</h2>
+        {!showForm && (
+          <button className="btn btn-primary" onClick={() => setShowForm(true)}>
+            <i className="material-icons">add</i>
+            创建作业
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <AssignmentForm
+          api={api}
+          onCreated={() => {
+            setShowForm(false);
+            load();
+          }}
+          onCancel={() => setShowForm(false)}
+        />
+      )}
+
+      {stats && (
+        <div className="stats-grid">
+          <div className="stat-card">
+            <div className="stat-number">{stats.totalAssignments || 0}</div>
+            <div className="stat-label">总作业数</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-number">{stats.activeAssignments || 0}</div>
+            <div className="stat-label">活跃作业</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-number">{stats.totalSubmissions || 0}</div>
+            <div className="stat-label">总提交数</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-number">
+              {stats.totalAssignments
+                ? Math.round((stats.totalSubmissions / stats.totalAssignments) * 100)
+                : 0}%
+            </div>
+            <div className="stat-label">平均完成率</div>
+          </div>
+        </div>
+      )}
+
+      <div className="card">
+        <div className="card-header">
+          <h3>作业列表</h3>
+          <div className="search-box">
+            <input
+              type="text"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="搜索作业..."
+              className="form-control"
+            />
+          </div>
+        </div>
+        <div className="table-container">
+          {loading && <p style={{ padding: '1rem' }}>加载中...</p>}
+          {error && <p className="text-error" style={{ padding: '1rem' }}>{error}</p>}
+          {!loading && !error && (
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>标题</th>
+                  <th>创建时间</th>
+                  <th>截止时间</th>
+                  <th>状态</th>
+                  <th>提交数</th>
+                  <th>操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((a) => (
+                  <tr
+                    key={a.id}
+                    className="assignment-row"
+                    onClick={() => openAssignment(a.id)}
+                  >
+                    <td>{a.title}</td>
+                    <td>{new Date(a.createdAt).toLocaleString()}</td>
+                    <td>
+                      {a.dueDate
+                        ? new Date(a.dueDate).toLocaleString()
+                        : '无限制'}
+                    </td>
+                    <td>{a.status || '未知'}</td>
+                    <td>{a.submissionCount || 0}</td>
+                    <td>
+                      <div className="action-buttons">
+                        <button
+                          className="action-btn view"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openAssignment(a.id);
+                          }}
+                        >
+                          <i className="material-icons">visibility</i>
+                        </button>
+                        <button
+                          className="action-btn"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            copyLink(a.id);
+                          }}
+                        >
+                          <i className="material-icons">link</i>
+                        </button>
+                        <button
+                          className="action-btn delete"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            deleteAssignment(a.id);
+                          }}
+                        >
+                          <i className="material-icons">delete</i>
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+                {filtered.length === 0 && (
+                  <tr>
+                    <td colSpan="6" className="text-center">
+                      暂无作业
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      {selected && (
+        <AssignmentDetails
+          assignment={selected}
+          onClose={() => setSelected(null)}
+          onDelete={(id) => {
+            deleteAssignment(id);
+            setSelected(null);
+          }}
+          copyLink={copyLink}
+        />
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/Classes.jsx
+++ b/frontend/src/components/admin/Classes.jsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react';
+
+export default function Classes({ api }) {
+  const [classes, setClasses] = useState([]);
+  const [newClass, setNewClass] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  async function load() {
+    try {
+      const data = await api.get('/api/classes');
+      setClasses(data.classes || []);
+      setError('');
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function add(e) {
+    e.preventDefault();
+    if (!newClass.trim()) return;
+    try {
+      await api.post('/api/classes', { className: newClass.trim() });
+      setNewClass('');
+      load();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  async function remove(name) {
+    try {
+      await api.del(`/api/classes/${encodeURIComponent(name)}`);
+      load();
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  return (
+    <div id="classes-tab" className="tab-content active">
+      <div className="page-header">
+        <h2>班级管理</h2>
+        <form onSubmit={add} style={{ display: 'flex', gap: '8px' }}>
+          <input
+            type="text"
+            value={newClass}
+            onChange={(e) => setNewClass(e.target.value)}
+            placeholder="班级名称"
+            className="form-control"
+          />
+          <button className="btn btn-primary" type="submit">
+            <i className="material-icons">add</i>
+            添加
+          </button>
+        </form>
+      </div>
+      <div className="card">
+        <div className="card-header">
+          <h3>班级列表</h3>
+        </div>
+        <div className="table-container">
+          {loading && <p style={{ padding: '1rem' }}>加载中...</p>}
+          {error && <p className="text-error" style={{ padding: '1rem' }}>{error}</p>}
+          {!loading && !error && (
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>班级名称</th>
+                  <th>操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                {classes.map((c) => (
+                  <tr key={c}>
+                    <td>{c}</td>
+                    <td>
+                      <button
+                        className="btn btn-secondary"
+                        onClick={() => remove(c)}
+                      >
+                        删除
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+                {classes.length === 0 && (
+                  <tr>
+                    <td colSpan="2" className="text-center">
+                      暂无班级
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/Modal.jsx
+++ b/frontend/src/components/admin/Modal.jsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+
+export default function Modal({ children, onClose }) {
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-window" onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/NavBar.jsx
+++ b/frontend/src/components/admin/NavBar.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export default function NavBar({ tab, onTabChange, onLogout }) {
+  function link(name, label) {
+    const cls = `nav-link${tab === name ? ' active' : ''}`;
+    return (
+      <a
+        href="#"
+        className={cls}
+        onClick={(e) => {
+          e.preventDefault();
+          onTabChange(name);
+        }}
+        data-tab={name}
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <nav className="nav">
+      <div className="nav-content">
+        <a href="/" className="nav-brand">
+          <i className="material-icons">school</i>
+          <span className="nav-brand-text">FirePolEd-Hub 管理后台</span>
+        </a>
+        <div className="nav-menu">
+          {link('assignments', '作业管理')}
+          {link('classes', '班级管理')}
+          {link('statistics', '统计分析')}
+          {link('settings', '系统设置')}
+          <button className="btn btn-secondary" onClick={onLogout} style={{ marginLeft: '1rem' }}>
+            <i className="material-icons">logout</i>
+            登出
+          </button>
+        </div>
+      </div>
+    </nav>
+  );
+}
+

--- a/frontend/src/components/admin/Settings.jsx
+++ b/frontend/src/components/admin/Settings.jsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+
+export default function Settings() {
+  const [name, setName] = useState('FirePolEd-Hub');
+  const [theme, setTheme] = useState('#018eee');
+  const [interval, setInterval] = useState(30);
+
+  function submit(e) {
+    e.preventDefault();
+    // In a real app this would save to server
+    // Here we simply log for demonstration
+    console.log('保存设置', { name, theme, interval });
+  }
+
+  return (
+    <div id="settings-tab" className="tab-content active">
+      <div className="page-header">
+        <h2>系统设置</h2>
+      </div>
+      <div className="card">
+        <div className="card-content">
+          <h3>基本设置</h3>
+          <form onSubmit={submit} id="settings-form">
+            <div className="form-group">
+              <label className="form-label">系统名称</label>
+              <input
+                type="text"
+                className="form-control"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">主题色</label>
+              <input
+                type="color"
+                className="form-control"
+                value={theme}
+                onChange={(e) => setTheme(e.target.value)}
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">自动保存间隔（秒）</label>
+              <input
+                type="number"
+                className="form-control"
+                value={interval}
+                min="10"
+                max="300"
+                onChange={(e) => setInterval(Number(e.target.value))}
+              />
+            </div>
+            <button type="submit" className="btn btn-primary">保存设置</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/Statistics.jsx
+++ b/frontend/src/components/admin/Statistics.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+
+export default function Statistics({ api }) {
+  const [stats, setStats] = useState(null);
+  const [activities, setActivities] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const s = await api.get('/api/stats');
+        const a = await api.get('/admin/assignments');
+        const recent = [];
+        if (a.assignments) {
+          for (const asg of a.assignments) {
+            try {
+              const detail = await api.get(
+                `/admin/assignments/${asg.id}/statistics`
+              );
+              detail.submissions.forEach((sub) =>
+                recent.push({ ...sub, assignmentTitle: asg.title })
+              );
+            } catch {
+              // ignore per-assignment errors
+            }
+          }
+        }
+        recent.sort(
+          (x, y) => new Date(y.submittedAt) - new Date(x.submittedAt)
+        );
+        if (mounted) {
+          setStats(s);
+          setActivities(recent.slice(0, 10));
+        }
+      } catch (e) {
+        if (mounted) setError(e.message);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [api]);
+
+  return (
+    <div id="statistics-tab" className="tab-content active">
+      <div className="page-header">
+        <h2>统计分析</h2>
+      </div>
+      {loading && <p>加载中...</p>}
+      {error && <p className="text-error">{error}</p>}
+      {!loading && !error && stats && (
+        <div className="stats-dashboard">
+          <div className="card">
+            <div className="card-content">
+              <h3>系统概览</h3>
+              <ul className="detail-list">
+                <li>总作业数：{stats.totalAssignments || 0}</li>
+                <li>活跃作业：{stats.activeAssignments || 0}</li>
+                <li>总提交数：{stats.totalSubmissions || 0}</li>
+                <li>最后更新：{stats.lastUpdated}</li>
+              </ul>
+            </div>
+          </div>
+          <div className="card">
+            <div className="card-content">
+              <h3>最近活动</h3>
+              {activities.length === 0 && <p>暂无活动</p>}
+              {activities.length > 0 && (
+                <ul className="activity-list">
+                  {activities.map((a) => (
+                    <li key={a.id} className="activity-item">
+                      <span className="activity-title">{a.assignmentTitle}</span>
+                      <span>
+                        {a.studentInfo.name}（{a.studentInfo.className}）
+                      </span>
+                      <span>{a.percentage}%</span>
+                      <span>{new Date(a.submittedAt).toLocaleString()}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/styles/admin-dashboard.css
+++ b/frontend/src/styles/admin-dashboard.css
@@ -1,92 +1,180 @@
-.admin-dashboard {
+.admin-layout {
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
   background: #f5f6fa;
   font-family: 'Roboto', -apple-system, BlinkMacSystemFont, sans-serif;
   color: #333;
 }
 
-.admin-header {
+.nav {
   background: #fff;
-  padding: 16px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  position: sticky;
-  top: 0;
-  z-index: 10;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.admin-header h1 {
-  margin: 0;
-  font-size: 1.5rem;
+.nav-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  height: 56px;
+  padding: 0 1rem;
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+  font-weight: 500;
+}
+
+.nav-brand .material-icons {
+  margin-right: 0.5rem;
+}
+
+.nav-menu {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.nav-link {
+  text-decoration: none;
+  color: #555;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.nav-link:hover {
+  background: rgba(1, 142, 238, 0.1);
+  color: #018eee;
+}
+
+.nav-link.active {
+  background: rgba(1, 142, 238, 0.2);
+  color: #018eee;
 }
 
 .admin-main {
-  display: flex;
-  flex-direction: column;
-}
-
-.assignment-list {
   flex: 1;
-  overflow-y: auto;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 24px 16px;
 }
 
-.assignment-item {
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.stats-dashboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.stat-card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.stat-number {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.stat-label {
+  color: #666;
+  margin-top: 4px;
+  font-size: 0.875rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  margin-bottom: 24px;
+}
+
+.card-content {
+  padding: 16px;
+}
+
+.card-header {
+  padding: 16px;
+  border-bottom: 1px solid #eee;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
   padding: 12px 16px;
   border-bottom: 1px solid #eee;
-  cursor: pointer;
+  text-align: left;
+  font-size: 0.9rem;
 }
 
-.assignment-item h3 {
-  margin: 0 0 4px;
-  font-size: 1rem;
+.table tr:hover {
+  background: #f0f7ff;
 }
 
-.assignment-item .assignment-meta {
-  margin: 0;
-  font-size: 0.875rem;
-  color: #666;
+.search-box input {
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
-.assignment-item:hover,
-.assignment-item.active {
-  background: #e8f0fe;
+.form-control {
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
-.assignment-detail {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: #fff;
-  padding: 20px;
-  overflow-y: auto;
-  z-index: 20;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
-}
-
-.detail-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+.form-group {
   margin-bottom: 16px;
 }
 
-.btn-close {
-  background: none;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-  line-height: 1;
+.form-label {
+  display: block;
+  margin-bottom: 4px;
+  font-weight: 500;
 }
 
-.detail-description {
-  margin: 0 0 16px;
-  line-height: 1.5;
+.text-center {
+  text-align: center;
+}
+
+.text-error {
+  color: #d32f2f;
 }
 
 .detail-list {
   list-style: none;
-  padding: 0;
+  padding: 16px;
   margin: 0;
 }
 
@@ -94,24 +182,128 @@
   margin-bottom: 8px;
 }
 
-.error {
-  color: #d32f2f;
-  padding: 12px;
+.table-container {
+  overflow-x: auto;
 }
 
-/* Desktop layout */
-@media (min-width: 768px) {
-  .admin-main {
-    flex-direction: row;
-  }
-  .assignment-list {
-    width: 35%;
-    border-right: 1px solid #eee;
-    max-height: calc(100vh - 64px);
-  }
-  .assignment-detail {
-    position: static;
-    width: 65%;
-    box-shadow: none;
-  }
+.tab-content {
+  display: none;
 }
+
+.tab-content.active {
+  display: block;
+}
+
+/* buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+  background: #e0e0e0;
+  color: #333;
+  transition: background 0.2s;
+}
+
+.btn-primary {
+  background: #018eee;
+  color: #fff;
+}
+
+.btn-secondary {
+  background: #f5f5f5;
+  color: #333;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.action-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: #555;
+}
+
+.action-btn.view {
+  color: #018eee;
+}
+
+.action-btn.delete {
+  color: #d32f2f;
+}
+
+.action-btn:hover {
+  opacity: 0.8;
+}
+
+/* detail view */
+.detail-tabs {
+  display: flex;
+  border-bottom: 1px solid #eee;
+}
+
+.detail-tabs button {
+  flex: 1;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  color: #555;
+}
+
+.detail-tabs button.active {
+  border-bottom: 2px solid #018eee;
+  color: #018eee;
+  font-weight: 500;
+}
+
+.submission-filters {
+  display: flex;
+  gap: 8px;
+}
+
+.submission-list {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0 0;
+}
+
+.submission-item {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  font-size: 0.875rem;
+  padding: 4px 0;
+}
+
+.activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.activity-item {
+  display: grid;
+  grid-template-columns: 2fr 2fr 1fr 2fr;
+  font-size: 0.875rem;
+  padding: 4px 0;
+}
+
+.activity-title {
+  font-weight: 500;
+}
+

--- a/frontend/src/styles/admin-dashboard.css
+++ b/frontend/src/styles/admin-dashboard.css
@@ -307,3 +307,27 @@
   font-weight: 500;
 }
 
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-window {
+  background: #fff;
+  max-width: 900px;
+  width: 90%;
+  max-height: 90%;
+  overflow-y: auto;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+


### PR DESCRIPTION
## Summary
- add assignment detail view with overview, submission records, and analytics
- show recent submission activity on statistics page
- extend admin dashboard styles for tabbed details and activity lists

## Testing
- `npm --prefix frontend run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab442452748321946f73cb3767cf3e